### PR TITLE
Insert last index at the end of the index array

### DIFF
--- a/Util.cpp
+++ b/Util.cpp
@@ -83,7 +83,7 @@ void Peaks::findPeaks(vector<float> x0, vector<int>& peakInds)
 
 
 	ind.insert(ind.begin(), 0);
-	ind.insert(ind.end(), len0);
+	ind.insert(ind.end(), len0 - 1);
 
 	int minMagIdx = distance(x.begin(), min_element(x.begin(), x.end()));
 	float minMag = x[minMagIdx];


### PR DESCRIPTION
This fixes the case when there is a peak in the last position of the array.

Test:

	vector<float> v{ 1.0, 1.0, 1.0, 2.0, 1.0, -1.0, 3.0, -2.5, 2.4, 2.4, 1.5, -1.2, 1.0};

	vector<int>inds;

	Peaks::findPeaks(v, inds);

	cout << "Peaks: ";
	for (auto& ind : inds) {
		cout << ind << " ";
	}

	cout << endl;
