### PR TITLE
Append end index instead of array size as last index. 

### DIFF
--- a/PeakFinder.cpp
+++ b/PeakFinder.cpp
@@ -70,7 +70,7 @@ void PeakFinder::findPeaks(std::vector<float> x0, std::vector<int>& peakInds, bo
 	int maxIdx = distance(x0.begin(), max_element(x0.begin(), x0.end()));
 
 	float sel = (x0[maxIdx]-x0[minIdx])/4.0;
-	int len0 = x0.size();
+	int endIdx = x0.size()-1;
 
 	scalarProduct(extrema, x0, x0);
 
@@ -96,9 +96,9 @@ void PeakFinder::findPeaks(std::vector<float> x0, std::vector<int>& peakInds, bo
 		selectElementsFromIndices(x0, ind, x);		
 		x.insert(x.begin(), x0[0]);
 		x.insert(x.end(), x0[x0.size()-1]);
-		//ind = [1;ind;len0];
+		//ind = [1;ind;endIdx];
 		ind.insert(ind.begin(), 1);
-		ind.insert(ind.end(), len0);
+		ind.insert(ind.end(), endIdx);
 		minMagIdx = distance(x.begin(), std::min_element(x.begin(), x.end()));
 		minMag = x[minMagIdx];		
 		//std::cout<<"Hola"<<std::endl;

--- a/example.cpp
+++ b/example.cpp
@@ -3,7 +3,7 @@
 
 int main()
 {
-	//float inArr[14] = {0,1,1,1,1,1,1,5,1,1,1,1,7};
+	//float inArr[14] = {0,1,1,1,1,1,1,5,1,1,1,1,1,7};
 	float inArr[4] =  { 1, 0, 0, 1 };
 
 	std::vector<float> in(inArr, inArr + sizeof(inArr) / sizeof(float));


### PR DESCRIPTION
closes #2
This repo is a translation from Matlab, which uses 1-based arrays. In Matlab, the array size and last index are the same. 

When considering endpoints, the first and last index are appended to the "ind" vector. The bug was that the size was used instead of the last index, causing access beyond the end of the array. 

In addition, the example code defines an array of 14 elements and populates 13 elements, hiding the bug if you try to test it with that code. This change corrects the size of the example array so that endpoints can be tested.

Before:

```
float inArr[14] = {0,1,1,1,1,1,1,5,1,1,1,1,1,7};
PeakFinder::findPeaks(in, out, false);
Maxima found:
5 

float inArr[14] = {0,1,1,1,1,1,1,5,1,1,1,1,1,7};
PeakFinder::findPeaks(in, out, true);
Maxima found:
5 0 
```

After 

```
float inArr[14] = {0,1,1,1,1,1,1,5,1,1,1,1,1,7};
PeakFinder::findPeaks(in, out, false);
Maxima found:
5 

float inArr[14] = {0,1,1,1,1,1,1,5,1,1,1,1,1,7};
PeakFinder::findPeaks(in, out, true);
Maxima found:
5 7 
```